### PR TITLE
Sett riktig scope for autentisering

### DIFF
--- a/src/backend/proxy.ts
+++ b/src/backend/proxy.ts
@@ -31,8 +31,8 @@ export const doProxy = (service: IService) => {
 export const attachToken = (authClient: Client, service: IService) => {
     return async (req: Request, _res: Response, next: NextFunction) => {
         const oboConfig: IApi = {
-            clientId: appConfig.clientId,
-            scopes: [service.azureScope],
+            clientId: service.clientId,
+            scopes: [],
         };
         getOnBehalfOfAccessToken(authClient, req, oboConfig).then((accessToken: string) => {
             req.headers['Nav-Call-Id'] = uuidv4();

--- a/src/backend/serviceConfig.ts
+++ b/src/backend/serviceConfig.ts
@@ -1,5 +1,5 @@
 export interface IService {
-    azureScope: string;
+    clientId: string;
     displayName: string;
     proxyPath: string;
     id: string;
@@ -12,41 +12,41 @@ if (process.env.ENV === 'local') {
         barnetrygd_mottak: 'http://localhost:8090',
         barnetrygd_sak: 'http://localhost:8089',
         enslig_mottak: 'http://localhost:8092',
-        kontantstøtte: 'http://localhost:8084',
+        kontantstøtte_mottak: 'http://localhost:8084',
     };
 } else {
     proxyUrls = {
         barnetrygd_mottak: `https://familie-ba-mottak.${process.env.ENV}-fss-pub.nais.io`,
         barnetrygd_sak: `https://familie-ba-sak.${process.env.ENV}-fss-pub.nais.io`,
         enslig_mottak: `https://familie-ef-mottak.${process.env.ENV}-fss-pub.nais.io`,
-        kontantstøtte: `https://familie-ks-mottak.${process.env.ENV}-fss-pub.nais.io`,
+        kontantstøtte_mottak: `https://familie-ks-mottak.${process.env.ENV}-fss-pub.nais.io`,
     };
 }
 
 export const serviceConfig: IService[] = [
     {
-        azureScope: process.env.KS_MOTTAK_SCOPE,
-        displayName: 'Kontantstøtte',
+        clientId: process.env.KS_MOTTAK_CLIENT_ID,
+        displayName: 'Kontantstøtte mottak',
         id: 'familie-ks-mottak',
         proxyPath: '/familie-ks-mottak/api',
-        proxyUrl: proxyUrls.kontantstøtte,
+        proxyUrl: proxyUrls.kontantstøtte_mottak,
     },
     {
-        azureScope: process.env.BA_MOTTAK_SCOPE,
+        clientId: process.env.BA_MOTTAK_CLIENT_ID,
         displayName: 'Barnetrygd mottak',
         id: 'familie-ba-mottak',
         proxyPath: '/familie-ba-mottak/api',
         proxyUrl: proxyUrls.barnetrygd_mottak,
     },
     {
-        azureScope: process.env.BA_SAK_SCOPE,
+        clientId: process.env.BA_SAK_CLIENT_ID,
         displayName: 'Barnetrygd sak',
         id: 'familie-ba-sak',
         proxyPath: '/familie-ba-sak/api',
         proxyUrl: proxyUrls.barnetrygd_sak,
     },
     {
-        azureScope: process.env.EF_MOTTAK_SCOPE,
+        clientId: process.env.EF_MOTTAK_CLIENT_ID,
         displayName: 'Alene med barn - mottak',
         id: 'familie-ef-mottak',
         proxyPath: '/familie-ef-mottak/api',


### PR DESCRIPTION
Scope ble cachet i felles, så vi fikk ikke oppdatert scope.
Å sende tom liste enforcer nytt scope. 

Oppdaterer også til mer beskrivende navn for ks (mottak).