### PR TITLE
Skal kunne paginere i prosesserings-verktøyet for å se eldre tasker

### DIFF
--- a/src/frontend/api/task.ts
+++ b/src/frontend/api/task.ts
@@ -18,12 +18,18 @@ export const hentTasks = (
 
 export const hentTasks2 = (
     valgtService: IService,
-    statusFilter: taskStatus
+    statusFilter: taskStatus,
+    side: number
 ): Promise<Ressurs<ITaskResponse>> => {
+    const params =
+        statusFilter !== taskStatus.ALLE
+            ? {
+                  status: statusFilter,
+                  page: side,
+              }
+            : { page: side };
     return axiosRequest({
-        params: statusFilter !== taskStatus.ALLE && {
-            status: statusFilter,
-        },
+        params,
         method: 'GET',
         url: `${valgtService.proxyPath}/v2/task`,
     });

--- a/src/frontend/komponenter/Felleskomponenter/Paginering/Paginering.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Paginering/Paginering.tsx
@@ -1,0 +1,39 @@
+import { Knapp } from 'nav-frontend-knapper';
+import { UndertekstBold } from 'nav-frontend-typografi';
+import * as React from 'react';
+import { actions as taskActions, useTaskContext, useTaskDispatch } from '../../TaskProvider';
+
+const Paginering: React.FunctionComponent = () => {
+    const side = useTaskContext().side;
+    const tasksDispatcher = useTaskDispatch();
+    return (
+        <div>
+            <Knapp
+                onClick={() =>
+                    tasksDispatcher({
+                        payload: side - 1,
+                        type: taskActions.SETT_SIDE,
+                    })
+                }
+                mini={true}
+                disabled={side <= 0}
+            >
+                Forrige
+            </Knapp>
+            <Knapp
+                onClick={() =>
+                    tasksDispatcher({
+                        payload: side + 1,
+                        type: taskActions.SETT_SIDE,
+                    })
+                }
+                mini={true}
+            >
+                Neste
+            </Knapp>
+            <UndertekstBold>Side: {side}</UndertekstBold>
+        </div>
+    );
+};
+
+export default Paginering;

--- a/src/frontend/komponenter/GruppertTasks/GruppertTasks.tsx
+++ b/src/frontend/komponenter/GruppertTasks/GruppertTasks.tsx
@@ -4,6 +4,7 @@ import { parse } from 'query-string';
 import { Normaltekst } from 'nav-frontend-typografi';
 import * as React from 'react';
 import { taskStatus, ITask } from '../../typer/task';
+import Paginering from '../Felleskomponenter/Paginering/Paginering';
 import { useTaskContext } from '../TaskProvider';
 import * as moment from 'moment';
 import * as classNames from 'classnames';
@@ -45,6 +46,7 @@ const GruppertTasks: React.FunctionComponent = () => {
                     <div className={'gruppert-tasks__container'}>
                         <div className={'gruppert-tasks__container--venstremeny'}>
                             <div className={'venstremeny'}>
+                                <Paginering />
                                 {Object.values(gruppertTasks).map((tasker: ITask[]) => {
                                     const sistKjørtTask = tasker[0];
                                     const displayCallId = sistKjørtTask.metadata.callId;

--- a/src/frontend/komponenter/GruppertTasks/gruppert-tasks.less
+++ b/src/frontend/komponenter/GruppertTasks/gruppert-tasks.less
@@ -18,7 +18,7 @@
                 flex: 1;
                 flex-direction: column;
                 background: white;
-                padding: 2rem 0;
+                padding: 1rem 0;
                 height: 100%;
                 max-width: 20rem;
                 min-width: 10rem;

--- a/src/frontend/komponenter/Task/Tasks.tsx
+++ b/src/frontend/komponenter/Task/Tasks.tsx
@@ -1,6 +1,7 @@
 import AlertStripe from 'nav-frontend-alertstriper';
 import * as React from 'react';
 import { RessursStatus } from '@navikt/familie-typer';
+import Paginering from '../Felleskomponenter/Paginering/Paginering';
 import { useTaskContext } from '../TaskProvider';
 import TaskListe from './TaskListe';
 import TopBar from '../Felleskomponenter/TopBar/TopBar';
@@ -15,6 +16,7 @@ const Tasks: React.FunctionComponent = () => {
                     <TopBar />
 
                     <br />
+                    <Paginering />
                     <TaskListe tasks={tasks.data.tasks} />
                 </div>
             );

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,25 +152,25 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@navikt/familie-backend@^5.0.4":
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/@navikt/familie-backend/-/familie-backend-5.0.15.tgz#e4a878660ff99b0f4347b2cf74538b29aac59a6a"
-  integrity sha512-Cl3CcJrEybEUMb0Z6Mj/nwfs0WKiJYkkfP54N4IOuJoPDWUQUFtXb0s2bo70BsE7oudXwgoVZlY1fr1T3ka1Mg==
+"@navikt/familie-backend@^5.0.17":
+  version "5.0.18"
+  resolved "https://registry.yarnpkg.com/@navikt/familie-backend/-/familie-backend-5.0.18.tgz#05a3b48da783c26ec5035eb7d17ec46695f5820a"
+  integrity sha512-z9HP+nNds2UWLu/dGYoT9yEw54bDTGex4a3rbT2zCIEqN0ru7dmvdHUhA3GtTS4TK80WJ9XR9+atiNG3s0uOpg==
   dependencies:
     "@types/cookie-parser" "^1.4.2"
-    "@types/express" "^4.17.2"
+    "@types/express" "^4.17.9"
     "@types/express-session" "^1.15.15"
     "@types/morgan" "^1.7.37"
     "@types/passport" "^1.0.1"
     "@types/redis" "^2.8.14"
     "@types/request-promise" "^4.1.46"
     "@types/tunnel" "^0.0.1"
-    axios "^0.19.2"
+    axios "^0.21.0"
     connect-redis "^5.0.0"
     cookie-parser "^1.4.4"
     express "^4.17.1"
     express-http-proxy "^1.6.0"
-    express-session "^1.17.0"
+    express-session "^1.17.1"
     https-proxy-agent "^5.0.0"
     moment-timezone "^0.5.27"
     openid-client "^4.2.0"
@@ -505,7 +505,7 @@
     "@types/express" "*"
     "@types/node" "*"
 
-"@types/express@*", "@types/express@^4.17.2":
+"@types/express@*":
   version "4.17.8"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.8.tgz#3df4293293317e61c60137d273a2e96cd8d5f27a"
   integrity sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==
@@ -1274,17 +1274,17 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
-
 axios@^0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
   integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
+  dependencies:
+    follow-redirects "^1.10.0"
+
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
     follow-redirects "^1.10.0"
 
@@ -2432,7 +2432,7 @@ debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@=3.1.0:
+debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -3047,7 +3047,7 @@ express-http-proxy@^1.6.0:
     es6-promise "^4.1.1"
     raw-body "^2.3.0"
 
-express-session@^1.17.0:
+express-session@^1.17.1:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.17.1.tgz#36ecbc7034566d38c8509885c044d461c11bf357"
   integrity sha512-UbHwgqjxQZJiWRTMyhvWGvjBQduGCSBDhhZXYenziMFjxst5rMV+aJZ6hKPHZnPyHGsrqRICxtX8jtEbm/z36Q==
@@ -3289,13 +3289,6 @@ fn.name@1.x.x:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
-
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.0"


### PR DESCRIPTION
Lagt inn svært simpel paginering med Neste/Forrige-knapp som ikke tar høyde for hvor mange tasker som finnes totalt sett, men bare går til neste side. Dette er noe vi trenger på EF da vi ofte ser at de "siste 100" taskene egentlig bare gir oss de siste 10 søknadene og vi ofte er interessert i tasker litt lenger bak i tid. 
---
<img width="352" alt="Skjermbilde 2021-01-26 kl  09 55 26" src="https://user-images.githubusercontent.com/402915/105822776-bb8cf680-5fbc-11eb-9a1b-6ab86675a5c1.png">
---
<img width="323" alt="Skjermbilde 2021-01-26 kl  09 55 19" src="https://user-images.githubusercontent.com/402915/105822781-bcbe2380-5fbc-11eb-80ed-5f2517da231e.png">
---
<img width="339" alt="Skjermbilde 2021-01-26 kl  09 55 14" src="https://user-images.githubusercontent.com/402915/105822785-bdef5080-5fbc-11eb-8186-86a1cacc4e1e.png">


