### PR TITLE
Vis triggertid på task

### DIFF
--- a/src/frontend/komponenter/Task/TaskPanel.tsx
+++ b/src/frontend/komponenter/Task/TaskPanel.tsx
@@ -57,6 +57,10 @@ const TaskPanel: FC<IProps> = ({ task }) => {
                         return <TaskElement key={key} label={key} innhold={task.metadata[key]} />;
                     })}
                     <TaskElement label={'Sist kjørt'} innhold={sistKjørt} />
+                    <TaskElement
+                        label={'Triggertid'}
+                        innhold={moment(task.triggerTid).format('DD.MM.YYYY HH:mm')}
+                    />
                 </div>
             </div>
 


### PR DESCRIPTION
Enkelte tasker har kjøretid frem i tid og da er det kjekt å kunne se triggertid på tasken

<img width="1057" alt="Screenshot 2021-12-21 at 14 37 23" src="https://user-images.githubusercontent.com/1121978/146939116-10fde63e-0cfc-4740-83ac-13637d565508.png">

