### PR TITLE
Lagt til mulighet til å filtrere på tasktype

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,6 @@ Ved spørsmål knyttet til koden eller prosjektet opprett en issue.
 ## For NAV-ansatte
 
 Interne henvendelser kan sendes via Slack i kanalen #team-familie.
+
+### Kode generert av GitHub Copilot
+Dette repoet bruker GitHub Copilot til å generere kode.

--- a/src/frontend/api/task.ts
+++ b/src/frontend/api/task.ts
@@ -51,6 +51,13 @@ export const hentTask = (valgtService: IService, taskId: number): Promise<Ressur
     });
 };
 
+export const hentAlleTasktyper = (valgtService: IService): Promise<Ressurs<string[]>> => {
+    return axiosRequest({
+        method: 'GET',
+        url: `${valgtService.proxyPath}/task/type/alle`,
+    });
+};
+
 export const hentTasksSomErFerdigNåMenFeiletFør = (
     valgtService: IService
 ): Promise<Ressurs<ITaskResponse>> => {

--- a/src/frontend/komponenter/Felleskomponenter/TopBar/TopBar.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/TopBar/TopBar.tsx
@@ -12,6 +12,9 @@ const TopBar: FC = () => {
         settStatusFilter,
         tasksSomErFerdigNåMenFeiletFør,
         hentEllerOppdaterTasks,
+        type,
+        typer,
+        settTypeFilter,
     } = useTaskContext();
     const { valgtService } = useServiceContext();
     const [visFeilaMenFerdig, setVisFeilaMenFerdig] = useState(false);
@@ -56,6 +59,26 @@ const TopBar: FC = () => {
                         return (
                             <option key={status} value={status}>
                                 {taskStatusTekster[status]}
+                            </option>
+                        );
+                    })}
+                </Select>
+                <Select
+                    onChange={(event) => settTypeFilter(event.target.value)}
+                    value={type}
+                    label={'Type'}
+                    style={{
+                        width: '22rem',
+                    }}
+                >
+                    <option key={'alle'} value={''}>
+                        Alle
+                    </option>
+
+                    {typer.map((type: string) => {
+                        return (
+                            <option key={type} value={type}>
+                                {type}
                             </option>
                         );
                     })}

--- a/src/frontend/komponenter/TaskProvider.tsx
+++ b/src/frontend/komponenter/TaskProvider.tsx
@@ -5,6 +5,7 @@ import { Location, useLocation } from 'react-router';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
     avvikshåndterTask,
+    hentAlleTasktyper,
     hentTask,
     hentTasks,
     hentTasksMedCallId,
@@ -54,6 +55,7 @@ const [TaskProvider, useTaskContext] = constate(() => {
     const [fagsystemFilter, settFagsystemFilter] = useState<Fagsystem>(Fagsystem.ALLE);
     const [side, settSide] = useState<number>(getQueryParamSide(location));
     const [type, settTypeFilter] = useState<string>(getQueryParamTaskType(location));
+    const [typer, settTyper] = useState<string[]>([]);
     const [taskId, settTaskId] = useState<number | undefined>(useGetParamTaskId());
     const [callId, settCallId] = useState<string | undefined>();
     const [task, settTask] = useState<Ressurs<ITask>>(byggTomRessurs());
@@ -72,6 +74,16 @@ const [TaskProvider, useTaskContext] = constate(() => {
 
     useEffect(() => {
         settFagsystemFilter(Fagsystem.ALLE);
+    }, [valgtService]);
+
+    useEffect(() => {
+        if (valgtService !== undefined) {
+            hentAlleTasktyper(valgtService).then((response) => {
+                if (response.status === RessursStatus.SUKSESS) {
+                    settTyper(response.data);
+                }
+            });
+        }
     }, [valgtService]);
 
     useEffect(() => {
@@ -160,6 +172,7 @@ const [TaskProvider, useTaskContext] = constate(() => {
         hentEllerOppdaterTasks,
         fagsystemFilter,
         settFagsystemFilter,
+        typer,
     };
 });
 


### PR DESCRIPTION
Mulighet til å filtrere tasker på taskType. Henter en liste med distincte tasktyper fra basen, og bruker disse typene til å filtrere

![image](https://github.com/user-attachments/assets/96dca026-1d50-4c2b-86b1-e5d2e7f74a7a)



Denne funksjonalitet trenger familie-prosessering-backend versjon senere enn 2.20250311132904_6ee7728 . Eller så blir resultatet
![image](https://github.com/user-attachments/assets/a69849f8-9035-4180-8f41-03263b154db7)

