### PR TITLE
Skru på logg-splitting til Elastic og Loki

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -17,6 +17,11 @@ spec:
   replicas:
     min: 1
     max: 1
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   ingresses:
     - "https://familie-prosessering.intern.dev.nav.no"
   azure:

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -17,6 +17,11 @@ spec:
   replicas:
     min: 1
     max: 1
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   ingresses:
     - "https://familie-prosessering.intern.nav.no"
   azure:


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Skrur på logg-splitting for app, som betyr at vi sender logs til både Elastic (Kibana) og (Grafana) Loki. Dette er en midlertidig løsning mens vi enda blir kjent med Loki og får satt opp ting slik vi ønsker det.

Favro: NAV-25157