### PR TITLE
Fikser styling med flytende knapp over textarea ved avvikshaandtering-modal

### DIFF
--- a/src/frontend/komponenter/Task/AvvikshåndteringModal/avvikshåndteringmodal.less
+++ b/src/frontend/komponenter/Task/AvvikshåndteringModal/avvikshåndteringmodal.less
@@ -9,4 +9,8 @@
     &__textarea {
         height: 10rem !important;
     }
+
+    & textarea {
+        max-height: 5.5rem;
+    }
 }


### PR DESCRIPTION
[Favro NAV-25719: Statisk button dekker til textarea i prosessering](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25719)

Knapp flyttet ikke på seg pga høyde på boks og textarea ble satt som fast så selv om textarea ble større ble den egentlig ikke det for styling dom og knappen ble værende. Ettersom jeg ser at textarea styling er satt til 10rem !important har jeg spesifisert nøyere at textarea som er vanligvis ca 88px har jeg sjekket er ca 5.5 rem, ikke blir høyere enn det og heller får en scrollbar. Da vil ikke textarea bli lenger, men bruker har fremdeles mulighet til å skrive inn mer, de må bare scrolle litt.

FØR
<img width="693" height="742" alt="image" src="https://github.com/user-attachments/assets/07d6a757-1fec-43d7-87a3-3994f64add23" />

https://github.com/user-attachments/assets/086d461f-1f14-4712-9602-c4f22c8109da

ETTER
<img width="726" height="762" alt="image" src="https://github.com/user-attachments/assets/fe4f9baf-ff68-4df9-aaf8-a7b747448adc" />

https://github.com/user-attachments/assets/21f07029-5916-4f01-8e44-4eee608f91bd


