### PR TITLE
fix: styling når bakgrunnen er hvit

### DIFF
--- a/src/frontend/komponenter/Task/tasks.less
+++ b/src/frontend/komponenter/Task/tasks.less
@@ -39,6 +39,14 @@
         &.MANUELL_OPPFØLGING {
             background-color: @ax-warning-500;
         }
+
+        &.UBEHANDLET,
+        &.KLAR_TIL_PLUKK,
+        &.PLUKKET,
+        &.BEHANDLER,
+        &.AVVIKSHÅNDTERT {
+            color: var(--ax-text-neutral);
+        }
     }
 
     &__rekjør {


### PR DESCRIPTION
Før:
<img width="356" height="442" alt="image" src="https://github.com/user-attachments/assets/cefa2831-4c9a-456a-acdd-cc814fb1e5db" />


Etter:
<img width="276" height="359" alt="image" src="https://github.com/user-attachments/assets/d2582c05-6d0d-4b7b-b24e-5726c63c5845" />
